### PR TITLE
Fixes fetch auth fix

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,13 +4,15 @@ import App from "./App";
 import "./index.css";
 
 const oldFetch = window.fetch;
-window.fetch = function fetch(url, settings) {
-  const headers = Object.assign(settings ? settings.headers : {},
-  {authorization: localStorage.getItem("token")});
-  settings = settings || {};
-  settings.headers = headers;
-  return oldFetch(url, settings);
-};
+window.fetch = (url, settings = {}) => (
+  oldFetch(url, {
+    ...settings,
+    headers: {
+      ...settings.headers,
+      authorization: localStorage.getItem("token"),
+    },
+  });
+);
 
 
 ReactDOM.render(


### PR DESCRIPTION
Previous method was throwing errors in cases where `settings.headers` were not defined:
`TypeError: Cannot convert undefined or null to object`